### PR TITLE
feat: add throw-error

### DIFF
--- a/source/rules/throw-error.ts
+++ b/source/rules/throw-error.ts
@@ -1,0 +1,62 @@
+/**
+ * @license Use of this source code is governed by an MIT-style license that
+ * can be found in the LICENSE file at https://github.com/cartant/eslint-plugin-rxjs
+ */
+
+import { Rule } from "eslint";
+import * as es from "estree";
+import { couldBeType, isAny } from "tsutils-etc";
+import { getTypeCheckerAndNodeMap } from "../utils";
+
+const rule: Rule.RuleModule = {
+  meta: {
+    docs: {
+      category: "RxJS",
+      description:
+        "Enforces the passing of Error values to error notifications.",
+      recommended: true
+    },
+    fixable: null,
+    messages: {
+      forbidden: "Passing non-Error values are forbidden."
+    },
+    schema: []
+  },
+  create: context => {
+    const { nodeMap, typeChecker } = getTypeCheckerAndNodeMap(context);
+
+    function report(node: es.Node) {
+      const tsNode = nodeMap.get(node);
+      const tsType = typeChecker.getTypeAtLocation(tsNode);
+
+      if (!isAny(tsType) && !couldBeType(tsType, "Error")) {
+        context.report({
+          messageId: "forbidden",
+          node
+        });
+      }
+    }
+
+    return {
+      "ThrowStatement[argument.type='Literal'] > Literal": (
+        node: es.Literal
+      ) => {
+        context.report({
+          messageId: "forbidden",
+          node
+        });
+      },
+      "ThrowStatement[argument.type='CallExpression'] > CallExpression": report,
+      "CallExpression[callee.name='throwError']": (node: es.CallExpression) => {
+        const tsNode = nodeMap.get(node);
+        const tsType = typeChecker.getTypeAtLocation(tsNode);
+
+        if (couldBeType(tsType, "Observable")) {
+          node.arguments.forEach(report);
+        }
+      }
+    };
+  }
+};
+
+export = rule;

--- a/source/rules/throw-error.ts
+++ b/source/rules/throw-error.ts
@@ -14,7 +14,7 @@ const rule: Rule.RuleModule = {
       category: "RxJS",
       description:
         "Enforces the passing of Error values to error notifications.",
-      recommended: true
+      recommended: false
     },
     fixable: null,
     messages: {

--- a/source/rules/throw-error.ts
+++ b/source/rules/throw-error.ts
@@ -38,15 +38,7 @@ const rule: Rule.RuleModule = {
     }
 
     return {
-      "ThrowStatement[argument.type='Literal'] > Literal": (
-        node: es.Literal
-      ) => {
-        context.report({
-          messageId: "forbidden",
-          node
-        });
-      },
-      "ThrowStatement[argument.type='CallExpression'] > CallExpression": report,
+      "ThrowStatement > *": report,
       "CallExpression[callee.name='throwError']": (node: es.CallExpression) => {
         const tsNode = nodeMap.get(node);
         const tsType = typeChecker.getTypeAtLocation(tsNode);

--- a/tests/rules/throw-error.ts
+++ b/tests/rules/throw-error.ts
@@ -1,0 +1,119 @@
+/**
+ * @license Use of this source code is governed by an MIT-style license that
+ * can be found in the LICENSE file at https://github.com/cartant/eslint-plugin-rxjs
+ */
+
+import { stripIndent } from "common-tags";
+import rule = require("../../source/rules/throw-error");
+import { ruleTester } from "../utils";
+
+ruleTester({ types: true }).run("throw-error", rule, {
+  valid: [
+    stripIndent`
+      const a = () => { throw new Error("error"); };
+    `,
+    stripIndent`
+      const a = () => { throw "error" as any };
+    `,
+    stripIndent`
+      const a = () => { throw errorMessage(); };
+
+      function errorMessage(): any {
+        return "error";
+      }
+    `,
+    stripIndent`
+      import { throwError } from "rxjs";
+
+      const ob1 = throwError(new Error("Boom!"));
+    `,
+    stripIndent`
+      import { throwError } from "rxjs";
+
+      const ob1 = throwError("Boom!" as any);
+    `,
+    stripIndent`
+      import { throwError } from "rxjs";
+
+      const ob1 = throwError(errorMessage());
+
+      function errorMessage(): any {
+        return "error";
+      }
+    `,
+    stripIndent`
+      // There will be no signature for callback and
+      // that should not effect and internal error.
+      declare const callback: Function;
+      callback();
+    `
+  ],
+  invalid: [
+    {
+      code: `const a = () => { throw "error"; };`,
+      errors: [
+        {
+          messageId: "forbidden",
+          line: 1,
+          column: 25,
+          endLine: 1,
+          endColumn: 32
+        }
+      ]
+    },
+    {
+      code: stripIndent`
+        const a = () => { throw errorMessage(); };
+
+        function errorMessage() {
+          return "error";
+        }
+      `,
+      errors: [
+        {
+          messageId: "forbidden",
+          line: 1,
+          column: 25,
+          endLine: 1,
+          endColumn: 39
+        }
+      ]
+    },
+    {
+      code: stripIndent`
+        import { throwError } from "rxjs";
+
+        const ob1 = throwError("Boom!");
+      `,
+      errors: [
+        {
+          messageId: "forbidden",
+          line: 3,
+          column: 24,
+          endLine: 3,
+          endColumn: 31
+        }
+      ]
+    },
+    {
+      code: stripIndent`
+        import { throwError } from "rxjs";
+
+        const ob1 = throwError(errorMessage());
+
+        function errorMessage() {
+          return "Boom!";
+        }
+      `,
+      errors: [
+        {
+          messageId: "forbidden",
+          line: 3,
+          column: 24,
+          endLine: 3,
+          endColumn: 38
+        }
+      ]
+    }
+  ]
+});

--- a/tests/rules/throw-error.ts
+++ b/tests/rules/throw-error.ts
@@ -81,6 +81,22 @@ ruleTester({ types: true }).run("throw-error", rule, {
     },
     {
       code: stripIndent`
+        const errorMessage = "Boom!";
+
+        const a = () => { throw errorMessage; };
+      `,
+      errors: [
+        {
+          messageId: "forbidden",
+          line: 3,
+          column: 25,
+          endLine: 3,
+          endColumn: 37
+        }
+      ]
+    },
+    {
+      code: stripIndent`
         import { throwError } from "rxjs";
 
         const ob1 = throwError("Boom!");


### PR DESCRIPTION
Part of #1

TSLint:

- https://github.com/cartant/rxjs-tslint-rules/blob/master/source/rules/rxjsThrowErrorRule.ts
- https://github.com/cartant/rxjs-tslint-rules/blob/master/test/v6/fixtures/throw-error/thrown/fixture.ts.lint
- https://github.com/cartant/rxjs-tslint-rules/blob/master/test/v6/fixtures/throw-error/notified/fixture.ts.lint

I didn't port over `Observable.throw` and `_throw` as these aren't in RxJS v6.