### PR TITLE
fix(deps): eslint-etc dependency range

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@typescript-eslint/experimental-utils": "^4.0.0",
     "common-tags": "^1.8.0",
     "decamelize": "^5.0.0",
-    "eslint-etc": "^4.0.0",
+    "eslint-etc": "^4.0.2",
     "requireindex": "~1.2.0",
     "rxjs-report-usage": "^1.0.4",
     "tslib": "^2.0.0",


### PR DESCRIPTION
eslint-etc.isProperty function used by no-implicit-any-catch (https://github.com/cartant/eslint-plugin-rxjs/blob/main/source/rules/no-implicit-any-catch.ts#L174) was only added in eslint-etc 4.0.2, so dependency range here was too lax as v4.0.1 or earlier satisfy the range but don't work.