### PR TITLE
no-unsafe-takeuntil: Accept object properties as operators

### DIFF
--- a/docs/rules/no-unsafe-takeuntil.md
+++ b/docs/rules/no-unsafe-takeuntil.md
@@ -24,7 +24,7 @@ const combined = source
 
 ## Options
 
-This rule accepts a single option which is an object with `alias` and `allow` properties. The `alias` property is an array of names of operators that should be treated similarly to `takeUntil` and the `allow` property is an array of names of operators that are safe to use after `takeUntil`.
+This rule accepts a single option which is an object with `alias`, `acceptObjectProperties` and `allow` properties. The `alias` property is an array of names of operators that should be treated similarly to `takeUntil`, the `acceptObjectProperties` property accepts operators as object properties or class methods (such as `operators.takeUntil` or `this.takeUntil`), and the `allow` property is an array of names of operators that are safe to use after `takeUntil`.
 
 By default, the `allow` property contains all of the built-in operators that are safe to use after `takeUntil`.
 

--- a/docs/rules/no-unsafe-takeuntil.md
+++ b/docs/rules/no-unsafe-takeuntil.md
@@ -24,7 +24,7 @@ const combined = source
 
 ## Options
 
-This rule accepts a single option which is an object with `alias`, `acceptObjectProperties` and `allow` properties. The `alias` property is an array of names of operators that should be treated similarly to `takeUntil`, the `acceptObjectProperties` property accepts operators as object properties or class methods (such as `operators.takeUntil` or `this.takeUntil`), and the `allow` property is an array of names of operators that are safe to use after `takeUntil`.
+This rule accepts a single option which is an object with `alias` and `allow` properties. The `alias` property is an array of names of operators that should be treated similarly to `takeUntil` and the `allow` property is an array of names of operators that are safe to use after `takeUntil`.
 
 By default, the `allow` property contains all of the built-in operators that are safe to use after `takeUntil`.
 

--- a/source/rules/no-unsafe-takeuntil.ts
+++ b/source/rules/no-unsafe-takeuntil.ts
@@ -17,7 +17,6 @@ import { ruleCreator } from "../utils";
 const defaultOptions: readonly {
   alias?: string[];
   allow?: string[];
-  acceptObjectProperties?: boolean;
 }[] = [];
 
 const rule = ruleCreator({
@@ -109,11 +108,7 @@ const rule = ruleCreator({
             let operatorName: string
             if (isIdentifier(arg.callee)) {
               operatorName = arg.callee.name
-            } else if (
-              config.acceptObjectProperties
-              && isMemberExpression(arg.callee)
-              && isIdentifier(arg.callee.property)
-            ) {
+            } else if (isMemberExpression(arg.callee) && isIdentifier(arg.callee.property)) {
               operatorName = arg.callee.property.name;
             } else {
               return "disallowed";

--- a/source/rules/no-unsafe-takeuntil.ts
+++ b/source/rules/no-unsafe-takeuntil.ts
@@ -10,12 +10,14 @@ import {
   getTypeServices,
   isCallExpression,
   isIdentifier,
+  isMemberExpression,
 } from "eslint-etc";
 import { ruleCreator } from "../utils";
 
 const defaultOptions: readonly {
   alias?: string[];
   allow?: string[];
+  acceptObjectProperties?: boolean;
 }[] = [];
 
 const rule = ruleCreator({
@@ -83,7 +85,7 @@ const rule = ruleCreator({
     const { couldBeObservable } = getTypeServices(context);
 
     return {
-      [`CallExpression[callee.property.name='pipe'] > CallExpression[callee.name=${checkedOperatorsRegExp}]`]:
+      [`CallExpression[callee.property.name='pipe'] > CallExpression[callee.name=${checkedOperatorsRegExp}], CallExpression[callee.property.name=${checkedOperatorsRegExp}]`]:
         (node: es.CallExpression) => {
           const pipeCallExpression = getParent(node) as es.CallExpression;
           if (
@@ -100,11 +102,24 @@ const rule = ruleCreator({
               return state;
             }
 
-            if (!isCallExpression(arg) || !isIdentifier(arg.callee)) {
+            if (!isCallExpression(arg)) {
               return "disallowed";
             }
 
-            if (checkedOperatorsRegExp.test(arg.callee.name)) {
+            let operatorName: string
+            if (isIdentifier(arg.callee)) {
+              operatorName = arg.callee.name
+            } else if (
+              config.acceptObjectProperties
+              && isMemberExpression(arg.callee)
+              && isIdentifier(arg.callee.property)
+            ) {
+              operatorName = arg.callee.property.name;
+            } else {
+              return "disallowed";
+            }
+
+            if (checkedOperatorsRegExp.test(operatorName)) {
               if (state === "disallowed") {
                 context.report({
                   messageId: "forbidden",
@@ -114,7 +129,7 @@ const rule = ruleCreator({
               return "taken";
             }
 
-            if (!allow.includes(arg.callee.name)) {
+            if (!allow.includes(operatorName)) {
               return "disallowed";
             }
             return state;

--- a/tests/rules/no-unsafe-takeuntil.ts
+++ b/tests/rules/no-unsafe-takeuntil.ts
@@ -170,6 +170,26 @@ ruleTester({ types: true }).run("no-unsafe-takeuntil", rule, {
     },
     {
       code: stripIndent`
+        // before switchMap as an alias and a class member without acceptObjectProperties
+        import { of } from "rxjs";
+        import { switchMap, takeUntil } from "rxjs/operators";
+
+        declare const untilDestroyed: Function;
+
+        const a = of("a");
+        const b = of("b");
+        const c = of("d");
+
+        const d = a.pipe(this.untilDestroyed(), switchMap(_ => b)).subscribe();
+      `,
+      options: [
+        {
+          alias: ["untilDestroyed"],
+        },
+      ],
+    },
+    {
+      code: stripIndent`
         // https://github.com/cartant/eslint-plugin-rxjs/issues/79
         import { of } from "rxjs";
         import { repeatWhen, takeUntil } from "rxjs/operators";
@@ -284,6 +304,30 @@ ruleTester({ types: true }).run("no-unsafe-takeuntil", rule, {
         options: [
           {
             alias: ["untilDestroyed"],
+          },
+        ],
+      }
+    ),
+    fromFixture(
+      stripIndent`
+        // before switchMap as an alias and a class member with acceptObjectProperties
+        import { of } from "rxjs";
+        import { switchMap, takeUntil } from "rxjs/operators";
+
+        declare const untilDestroyed: Function;
+
+        const a = of("a");
+        const b = of("b");
+        const c = of("d");
+
+        const d = a.pipe(this.untilDestroyed(), switchMap(_ => b)).subscribe();
+                         ~~~~~~~~~~~~~~~~~~~ [forbidden]
+      `,
+      {
+        options: [
+          {
+            alias: ["untilDestroyed"],
+            acceptObjectProperties: true,
           },
         ],
       }

--- a/tests/rules/no-unsafe-takeuntil.ts
+++ b/tests/rules/no-unsafe-takeuntil.ts
@@ -170,26 +170,6 @@ ruleTester({ types: true }).run("no-unsafe-takeuntil", rule, {
     },
     {
       code: stripIndent`
-        // before switchMap as an alias and a class member without acceptObjectProperties
-        import { of } from "rxjs";
-        import { switchMap, takeUntil } from "rxjs/operators";
-
-        declare const untilDestroyed: Function;
-
-        const a = of("a");
-        const b = of("b");
-        const c = of("d");
-
-        const d = a.pipe(this.untilDestroyed(), switchMap(_ => b)).subscribe();
-      `,
-      options: [
-        {
-          alias: ["untilDestroyed"],
-        },
-      ],
-    },
-    {
-      code: stripIndent`
         // https://github.com/cartant/eslint-plugin-rxjs/issues/79
         import { of } from "rxjs";
         import { repeatWhen, takeUntil } from "rxjs/operators";
@@ -310,7 +290,7 @@ ruleTester({ types: true }).run("no-unsafe-takeuntil", rule, {
     ),
     fromFixture(
       stripIndent`
-        // before switchMap as an alias and a class member with acceptObjectProperties
+        // before switchMap as an alias and a class member
         import { of } from "rxjs";
         import { switchMap, takeUntil } from "rxjs/operators";
 
@@ -327,7 +307,6 @@ ruleTester({ types: true }).run("no-unsafe-takeuntil", rule, {
         options: [
           {
             alias: ["untilDestroyed"],
-            acceptObjectProperties: true,
           },
         ],
       }


### PR DESCRIPTION
## Motivation

I wanted to add the rule for the custom `takeUntilDestroy` operator in our working project. The operator is the method of an angular component, which fires when `ngOnDestroy` is called. But I stumbled upon the issue that the rule ignores my method:

```json
// .eslintrc.json

"rxjs/no-unsafe-takeuntil": [
  "error",
  {
    "alias": ["takeUntilDestroy"]
  }
]
```

```ts
// My method

of(null)
  .pipe(
    this.takeUntilDestroy(), // It doesn't say anything
    tap(() => {}),
  )
  .subscribe(() => {});
```

## Solution
I added the new option `acceptObjectProperties` (`false` by default) which allows adding not only functions but object properties and class members. So with this config:

```json
// .eslintrc.json

"rxjs/no-unsafe-takeuntil": [
  "error",
  {
    "alias": ["takeUntilDestroy"],
    "acceptObjectProperties": true
  }
]
```

eslint would highlight the problem method:

```ts
// My method

of(null)
  .pipe(
    this.takeUntilDestroy(), // Applying operators after takeUntil is forbidden.
    tap(() => {}),
  )
  .subscribe(() => {});
```
