### PR TITLE
feat(prefer-observer): add fix suggestions

### DIFF
--- a/source/rules/prefer-observer.ts
+++ b/source/rules/prefer-observer.ts
@@ -3,7 +3,10 @@
  * can be found in the LICENSE file at https://github.com/cartant/eslint-plugin-rxjs
  */
 
-import { TSESTree as es } from "@typescript-eslint/experimental-utils";
+import {
+  TSESTree as es,
+  TSESLint as eslint,
+} from "@typescript-eslint/experimental-utils";
 import {
   getTypeServices,
   isArrowFunctionExpression,
@@ -24,8 +27,8 @@ const rule = ruleCreator({
         "Forbids the passing separate handlers to `subscribe` and `tap`.",
       recommended: false,
     },
-    fixable: undefined,
-    hasSuggestions: false,
+    fixable: "code",
+    hasSuggestions: true,
     messages: {
       forbidden:
         "Passing separate handlers is forbidden; pass an observer instead.",
@@ -51,10 +54,64 @@ const rule = ruleCreator({
       if (isMemberExpression(callee) && !couldBeObservable(callee.object)) {
         return;
       }
+
+      function* fix(fixer: eslint.RuleFixer) {
+        const sourceCode = context.getSourceCode();
+        const [nextArg, errorArg, completeArg] = args;
+        const nextArgText = nextArg ? sourceCode.getText(nextArg) : "";
+        const errorArgText = errorArg ? sourceCode.getText(errorArg) : "";
+        const completeArgText = completeArg
+          ? sourceCode.getText(completeArg)
+          : "";
+        let observer = "{";
+        if (
+          nextArgText &&
+          nextArgText !== "undefined" &&
+          nextArgText !== "null"
+        ) {
+          observer += ` next: ${nextArgText}${
+            isValidArgText(errorArgText) || isValidArgText(completeArgText)
+              ? ","
+              : ""
+          }`;
+        }
+        if (
+          errorArgText &&
+          errorArgText !== "undefined" &&
+          errorArgText !== "null"
+        ) {
+          observer += ` error: ${errorArgText}${
+            isValidArgText(completeArgText) ? "," : ""
+          }`;
+        }
+        if (
+          completeArgText &&
+          completeArgText !== "undefined" &&
+          completeArgText !== "null"
+        ) {
+          observer += ` complete: ${completeArgText}`;
+        }
+        observer += " }";
+
+        yield fixer.replaceText(callExpression.arguments[0], observer);
+
+        const [, start] = callExpression.arguments[0].range;
+        const [, end] =
+          callExpression.arguments[callExpression.arguments.length - 1].range;
+        yield fixer.removeRange([start, end]);
+      }
+
       if (args.length > 1) {
         context.report({
           messageId: "forbidden",
           node: reportNode,
+          fix,
+          suggest: [
+            {
+              messageId: "forbidden",
+              fix,
+            },
+          ],
         });
       } else if (args.length === 1 && !allowNext) {
         const [arg] = args;
@@ -66,6 +123,13 @@ const rule = ruleCreator({
           context.report({
             messageId: "forbidden",
             node: reportNode,
+            fix,
+            suggest: [
+              {
+                messageId: "forbidden",
+                fix,
+              },
+            ],
           });
         }
       }
@@ -82,3 +146,7 @@ const rule = ruleCreator({
 });
 
 export = rule;
+
+function isValidArgText(argText: string) {
+  return argText && argText !== "undefined" && argText !== "null";
+}


### PR DESCRIPTION
I've (attempted at least) to add a rudimentary fix for instances where users are using the deprecated signatures of `tap` and `subscribe`.