### PR TITLE
Fix eslint-etc issue where hasTypeAnnotation function does not evaluate 'typeAnnotation' properly in call cases.

### DIFF
--- a/source/rules/no-implicit-any-catch.ts
+++ b/source/rules/no-implicit-any-catch.ts
@@ -10,7 +10,6 @@ import {
 } from "@typescript-eslint/experimental-utils";
 import {
   getTypeServices,
-  hasTypeAnnotation,
   isArrowFunctionExpression,
   isFunctionExpression,
   isIdentifier,
@@ -87,7 +86,7 @@ const rule = ruleCreator({
         if (!param) {
           return;
         }
-        if (hasTypeAnnotation(param)) {
+        if (param.typeAnnotation) {
           const { typeAnnotation } = param;
           const {
             typeAnnotation: { type },


### PR DESCRIPTION
The `recommended` config crashes eslint due to an issue with undefined property detection/testing.

The intended behavior of hasOwnProperty only seems to work when a property is explicitly set as undefined. When values are implicitly set.  This behavior is consistent with `Object.hasOwn`, `object.hasOwnProperty` and `'property' in object`.

[Here is a TS Playground demonstrating this behavior](https://www.typescriptlang.org/play/?#code/JYOwLgpgTgZghgYwgAgBJwM4BUCeAHCAQRBAHsw4xhSRkBvAKAEgQ4BbCALmQzClADmAGmZh8REuUrUQAfm4BXEABMIMUBGXIAPslIAjAFYQEYBgF8GDBDV7IIADzwAbYAmBhnOAKoq1G5W50bHFiMgoqGmQAXnpmVg5uAHJHFzcPL19VdRBNJJEmMQIwqUiQRT8czQsrGxA7YDY0908fSoCgzFxiyQiZGLiWdi5kJMbmjLbsgKSa61tSZwgAOmdSAQAKOlTXFsz23OUhZHHdyaz-Q-MASlqFpdX1jaSAeSMTMGWAC0wXgHcQPlBjt0q0LlVAsg3sZTN9fgCNiC9lNLppjkkihJwtIaElrgVTqD9tNDtxoR84Rh-iANoTkeCAujMSU+rjbjc7vVFis1pskgYYZ8flSAQAFKCkAhQMRAxhMJHnA6abgKsFK5SU6niyXQMTPZm9HGA-HMOmKknKk5NM5qi0a4VaiVSvUY0KGsp4iy3eZch68-Vu7FlE60Byy5iq4moyGunpBmRJEP2Jw2qMQgnWokoiHJA3x3FJs226NezkYbmPPkAQirDmWedKCeOcsj2Y6yBrrYZh3rgcbNAzE2LOY7VaLaYCvbj-ZApYYwBgGyrXfVU6xM+ucrq5b9TxSKaz3c0yGFyHgzgwOGQDdZxrmC6X47bPZvRs3zG3Ff9Y0z9PVJ8wM84AvK9Xw9dkgA).

Only `if(obj.typeAnnotation)` and `!!obj.typeAnnotation` both consistently return false.

The easiest way to check for a typeAnnotation at this branch is to simply check for truthiness with `if(param.typeAnnotation)`, which I have implemented in this PR.

Fixes #122 